### PR TITLE
Octokit auto_paginate

### DIFF
--- a/lib/github-copywriter.rb
+++ b/lib/github-copywriter.rb
@@ -19,6 +19,7 @@ class Copywriter
 
     def initialize(username, password)
         # Auth to GitHub
+        Octokit.auto_paginate = true
         @client = Octokit::Client.new(:login => username, :password => password)
 
         # Check if the basic_auth worked.


### PR DESCRIPTION
There was limit for only few repositories, so I enabled Octokit [auto_paginate](https://github.com/octokit/octokit.rb#pagination) so github-copywriter now iterates through **all repos** :+1: :santa: 
